### PR TITLE
DC-2007 - Bumped JUnit from 4.9 to 4.12. 

### DIFF
--- a/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/GeneralPackageDescriptionCreatorTest.java
+++ b/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/GeneralPackageDescriptionCreatorTest.java
@@ -32,12 +32,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import net.lingala.zip4j.core.ZipFile;
 
@@ -359,7 +354,7 @@ public class GeneralPackageDescriptionCreatorTest {
     /* Verify that symlink cycles can be detected */
     @Test
     public void simLinkCycleTest() throws Exception {
-        File tempDir = tmpfolder.newFolder("moo");
+        File tempDir = tmpfolder.newFolder(UUID.randomUUID().toString());
 
         File subdir = new File(tempDir, "cow");
         subdir.mkdir();
@@ -371,7 +366,6 @@ public class GeneralPackageDescriptionCreatorTest {
             Files.createSymbolicLink(link, subdir.toPath());
         } catch (UnsupportedOperationException e) {
             /* Nothing we can do if the system doesn't support symlinks */
-            FileUtils.deleteDirectory(tempDir);
             return;
         }
 
@@ -380,8 +374,6 @@ public class GeneralPackageDescriptionCreatorTest {
             Assert.fail("Expected symbolic link cycle to cause an exception");
         } catch (PackageDescriptionCreatorException e) {
             /* Expected */
-            // clean up just in case other tests create the same dirs/files
-            FileUtils.deleteDirectory(tempDir);
         }
 
     }
@@ -390,7 +382,7 @@ public class GeneralPackageDescriptionCreatorTest {
     //TODO: These setReadable false tests don't work on windows for now the test only runs if that operation succeeded.
     @Test
     public void nonreadableFileTest() throws Exception {
-        File tempDir = tmpfolder.newFolder("moo");
+        File tempDir = tmpfolder.newFolder(UUID.randomUUID().toString());
 
         File subdir = new File(tempDir, "cow");
         subdir.mkdir();
@@ -402,10 +394,6 @@ public class GeneralPackageDescriptionCreatorTest {
                 Assert.fail("Expected a non-readable directory to cause an exception");
             } catch (PackageDescriptionCreatorException e) {
                 /* Expected */
-                // clean up just in case other tests create the same dirs/files. Can't use
-                // FileUtils due to readable false
-                subdir.delete();
-                tempDir.delete();
             }
         }
 

--- a/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/GeneralPackageDescriptionCreatorTest.java
+++ b/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/GeneralPackageDescriptionCreatorTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import net.lingala.zip4j.core.ZipFile;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.dataconservancy.packaging.tool.api.PackageDescriptionCreator;
 import org.dataconservancy.packaging.tool.api.PackageDescriptionCreatorException;
@@ -370,6 +371,7 @@ public class GeneralPackageDescriptionCreatorTest {
             Files.createSymbolicLink(link, subdir.toPath());
         } catch (UnsupportedOperationException e) {
             /* Nothing we can do if the system doesn't support symlinks */
+            FileUtils.deleteDirectory(tempDir);
             return;
         }
 
@@ -378,6 +380,8 @@ public class GeneralPackageDescriptionCreatorTest {
             Assert.fail("Expected symbolic link cycle to cause an exception");
         } catch (PackageDescriptionCreatorException e) {
             /* Expected */
+            // clean up just in case other tests create the same dirs/files
+            FileUtils.deleteDirectory(tempDir);
         }
 
     }
@@ -398,8 +402,13 @@ public class GeneralPackageDescriptionCreatorTest {
                 Assert.fail("Expected a non-readable directory to cause an exception");
             } catch (PackageDescriptionCreatorException e) {
                 /* Expected */
+                // clean up just in case other tests create the same dirs/files. Can't use
+                // FileUtils due to readable false
+                subdir.delete();
+                tempDir.delete();
             }
         }
+
     }
 
     /* Verify that DataItem+DataFile files are sane (DC-1717) */

--- a/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/PackageDescriptionValidatorTest.java
+++ b/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/PackageDescriptionValidatorTest.java
@@ -19,6 +19,7 @@ package org.dataconservancy.packaging.tool.impl;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -54,7 +55,7 @@ public class PackageDescriptionValidatorTest {
     
 
     @BeforeClass
-    public static void setup() {
+    public static void setup() throws IOException {
         TMP_DIR = tmpfolder.newFolder("test");
     }
     

--- a/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/OrePackageModelBuilderTest.java
+++ b/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/generator/OrePackageModelBuilderTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Path;
@@ -450,7 +451,7 @@ public class OrePackageModelBuilderTest {
     }
 
     @Test(expected = Exception.class)
-    public void badPropertyTest() {
+    public void badPropertyTest() throws IOException {
         OrePackageModelBuilder builder = new OrePackageModelBuilder();
         PackageAssembler assembler =
                 new FunctionalAssemblerMock(tmpfolder.newFolder("clover"));

--- a/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/rules/operations/Value_FileMetadataTest.java
+++ b/dcs-packaging-tool/dcs-packaging-tool-impl/src/test/java/org/dataconservancy/packaging/tool/impl/rules/operations/Value_FileMetadataTest.java
@@ -43,7 +43,7 @@ public class Value_FileMetadataTest {
 
     /* Verifies that the fileType of a directory is Directory */
     @Test
-    public void fileTypeDirectoryTest() {
+    public void fileTypeDirectoryTest() throws IOException {
         Value_FileMetadata metadata = new Value_FileMetadata();
         metadata.setSpecifier(FileAttribute.fileType.toString());
 

--- a/dcs-packaging-tool/pom.xml
+++ b/dcs-packaging-tool/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.dataconservancy</groupId>
     <artifactId>project-pom</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   
   <!-- Modules  =================================================== -->

--- a/dcs-shared-util/pom.xml
+++ b/dcs-shared-util/pom.xml
@@ -35,7 +35,7 @@
   <parent>
     <groupId>org.dataconservancy</groupId>
     <artifactId>project-pom</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <!-- Build  ===================================================== -->

--- a/dcs-shared-util/src/test/java/org/dataconservancy/dcs/util/FilePathUtilTest.java
+++ b/dcs-shared-util/src/test/java/org/dataconservancy/dcs/util/FilePathUtilTest.java
@@ -23,6 +23,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.UUID;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -94,12 +95,10 @@ public class FilePathUtilTest {
     public void testRelativizeAlreadyRelativeFile() throws IOException {
         final String expectedPath = File.separator + "test" + File.separator + "file.txt";
         final File relativeFile = new File("/test/file.txt");
-        final File directory = tmpFolder.newFolder("test");
+        final File directory = tmpFolder.newFolder(UUID.randomUUID().toString());
         final String resultPath = FilePathUtil.relativizePath(directory.getPath(), relativeFile);
 
         assertTrue("Expected: " + expectedPath + " but was: " + resultPath, expectedPath.equalsIgnoreCase(resultPath));
-        // clean up just in case other tests create the same dirs/files
-        FileUtils.deleteDirectory(directory);
     }
 
     /**
@@ -108,14 +107,12 @@ public class FilePathUtilTest {
     @Test
     public void testRelativizeAbsoluteFile() throws IOException {
         final String expectedPath = "relative" + File.separator + "file.txt";
-        final File directory = tmpFolder.newFolder("test");
+        final File directory = tmpFolder.newFolder(UUID.randomUUID().toString());
 
         final File relativeFile = new File(directory, "/relative/file.txt");
         final String resultPath = FilePathUtil.relativizePath(directory.getPath(), relativeFile);
 
         assertTrue("Expected: " + expectedPath + " but was: " + resultPath, expectedPath.equalsIgnoreCase(resultPath));
-        // clean up just in case other tests create the same dirs/files
-        FileUtils.deleteDirectory(directory);
     }
 
     /**
@@ -125,13 +122,11 @@ public class FilePathUtilTest {
     public void testRelativizeFileNotUnderBasePath() throws IOException {
         final File testFile = new File("foo", "test.file");
         final String expectedPath = testFile.getPath();
-        final File directory = tmpFolder.newFolder("test");
+        final File directory = tmpFolder.newFolder(UUID.randomUUID().toString());
 
         final String resultPath = FilePathUtil.relativizePath(directory.getPath(), testFile);
 
         assertTrue("Expected: " + expectedPath + " but was: " + resultPath, expectedPath.equalsIgnoreCase(resultPath));
-        // clean up just in case other tests create the same dirs/files
-        FileUtils.deleteDirectory(directory);
     }
 
     /**
@@ -544,10 +539,8 @@ public class FilePathUtilTest {
      */
     @Test
     public void testAbsolutizeNullBaseFile() throws IOException {
-        File testFile = tmpFolder.newFile("test");
+        File testFile = tmpFolder.newFile(UUID.randomUUID().toString());
         assertNull(FilePathUtil.absolutize(null, testFile));
-        // clean up just in case other tests create the same dirs/files
-        FileUtils.deleteQuietly(testFile);
     }
 
     /**
@@ -555,10 +548,8 @@ public class FilePathUtilTest {
      */
     @Test
     public void testAbsolutizeNullFile() throws IOException {
-        File testFolder = tmpFolder.newFolder("test");
+        File testFolder = tmpFolder.newFolder(UUID.randomUUID().toString());
         assertNull(FilePathUtil.absolutize(testFolder, null));
-        // clean up just in case other tests create the same dirs/files
-        FileUtils.deleteDirectory(testFolder);
     }
 
     /**
@@ -566,15 +557,13 @@ public class FilePathUtilTest {
      */
     @Test
     public void testAbsolutizeAlreadyAbsoluteFile() throws IOException {
-        final File testDir = tmpFolder.newFolder("absolute");
+        final File testDir = tmpFolder.newFolder(UUID.randomUUID().toString());
         final File testFile = new File(testDir, "testFile");
 
         File returnedFile = FilePathUtil.absolutize(testDir, testFile);
 
         assertTrue("Expected: " + testFile.getPath() + " but was: " +
                        returnedFile.getPath(), testFile.getPath().equalsIgnoreCase(returnedFile.getPath()));
-        // clean up just in case other tests create the same dirs/files
-        FileUtils.deleteDirectory(testDir);
     }
 
     /**
@@ -582,14 +571,12 @@ public class FilePathUtilTest {
      */
     @Test
     public void testAbsolutizeFile() throws IOException {
-        final File testDir = tmpFolder.newFolder("absolute");
+        final File testDir = tmpFolder.newFolder(UUID.randomUUID().toString());
         final File testFile = new File("testFile");
         final String expectedPath = testDir.getPath() + File.separator + testFile.getPath();
         File returnedFile = FilePathUtil.absolutize(testDir, testFile);
 
         assertTrue("Expected: " + expectedPath + " but was: " + returnedFile.getPath(), expectedPath.equalsIgnoreCase(returnedFile.getPath()));
-        // clean up just in case other tests create the same dirs/files
-        FileUtils.deleteDirectory(testDir);
     }
 
     /**
@@ -690,8 +677,6 @@ public class FilePathUtilTest {
     public void testIllegalCharacterDetectedInPath() throws IOException {
         final File testFile = tmpFolder.newFolder("badFileName:oops");
         Assert.assertFalse(FilePathUtil.hasValidFilePath(testFile));
-        // clean up just in case other tests create the same dirs/files
-        FileUtils.deleteDirectory(testFile);
     }
 
     /**

--- a/dcs-shared-util/src/test/java/org/dataconservancy/dcs/util/FilePathUtilTest.java
+++ b/dcs-shared-util/src/test/java/org/dataconservancy/dcs/util/FilePathUtilTest.java
@@ -15,6 +15,7 @@
  */
 package org.dataconservancy.dcs.util;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -90,29 +91,31 @@ public class FilePathUtilTest {
      * Tests that if a file is already the relative it's unchanged by the relativize method.
      */
     @Test
-    public void testRelativizeAlreadyRelativeFile() {
+    public void testRelativizeAlreadyRelativeFile() throws IOException {
         final String expectedPath = File.separator + "test" + File.separator + "file.txt";
         final File relativeFile = new File("/test/file.txt");
         final File directory = tmpFolder.newFolder("test");
-        directory.deleteOnExit();
         final String resultPath = FilePathUtil.relativizePath(directory.getPath(), relativeFile);
 
         assertTrue("Expected: " + expectedPath + " but was: " + resultPath, expectedPath.equalsIgnoreCase(resultPath));
+        // clean up just in case other tests create the same dirs/files
+        FileUtils.deleteDirectory(directory);
     }
 
     /**
      * Tests that if a file is absolute it's made relative.
      */
     @Test
-    public void testRelativizeAbsoluteFile() {
+    public void testRelativizeAbsoluteFile() throws IOException {
         final String expectedPath = "relative" + File.separator + "file.txt";
         final File directory = tmpFolder.newFolder("test");
-        directory.deleteOnExit();
 
         final File relativeFile = new File(directory, "/relative/file.txt");
         final String resultPath = FilePathUtil.relativizePath(directory.getPath(), relativeFile);
 
         assertTrue("Expected: " + expectedPath + " but was: " + resultPath, expectedPath.equalsIgnoreCase(resultPath));
+        // clean up just in case other tests create the same dirs/files
+        FileUtils.deleteDirectory(directory);
     }
 
     /**
@@ -123,12 +126,12 @@ public class FilePathUtilTest {
         final File testFile = new File("foo", "test.file");
         final String expectedPath = testFile.getPath();
         final File directory = tmpFolder.newFolder("test");
-        directory.deleteOnExit();
-        testFile.deleteOnExit();
 
         final String resultPath = FilePathUtil.relativizePath(directory.getPath(), testFile);
 
         assertTrue("Expected: " + expectedPath + " but was: " + resultPath, expectedPath.equalsIgnoreCase(resultPath));
+        // clean up just in case other tests create the same dirs/files
+        FileUtils.deleteDirectory(directory);
     }
 
     /**
@@ -143,10 +146,8 @@ public class FilePathUtilTest {
      * Test that if the base file is null the original file is returned.
      */
     @Test
-    public void testRelativizeNullBaseFile() {
+    public void testRelativizeNullBaseFile() throws IOException {
         final String expectedPath = "relative" + File.separator + "file.txt";
-        final File directory = tmpFolder.newFolder("test");
-        directory.deleteOnExit();
 
         final File relativeFile = new File("relative/file.txt");
         final String resultPath = FilePathUtil.relativizePath(null, relativeFile);
@@ -543,22 +544,28 @@ public class FilePathUtilTest {
      */
     @Test
     public void testAbsolutizeNullBaseFile() throws IOException {
-        assertNull(FilePathUtil.absolutize(null, tmpFolder.newFile("test")));
+        File testFile = tmpFolder.newFile("test");
+        assertNull(FilePathUtil.absolutize(null, testFile));
+        // clean up just in case other tests create the same dirs/files
+        FileUtils.deleteQuietly(testFile);
     }
 
     /**
      * Tests that null is returned if the file to absolutize is null
      */
     @Test
-    public void testAbsolutizeNullFile() {
-        assertNull(FilePathUtil.absolutize(tmpFolder.newFolder("test"), null));
+    public void testAbsolutizeNullFile() throws IOException {
+        File testFolder = tmpFolder.newFolder("test");
+        assertNull(FilePathUtil.absolutize(testFolder, null));
+        // clean up just in case other tests create the same dirs/files
+        FileUtils.deleteDirectory(testFolder);
     }
 
     /**
      * Tests that if the file is already absolute absolutize returns the same file.
      */
     @Test
-    public void testAbsolutizeAlreadyAbsoluteFile() {
+    public void testAbsolutizeAlreadyAbsoluteFile() throws IOException {
         final File testDir = tmpFolder.newFolder("absolute");
         final File testFile = new File(testDir, "testFile");
 
@@ -566,19 +573,23 @@ public class FilePathUtilTest {
 
         assertTrue("Expected: " + testFile.getPath() + " but was: " +
                        returnedFile.getPath(), testFile.getPath().equalsIgnoreCase(returnedFile.getPath()));
+        // clean up just in case other tests create the same dirs/files
+        FileUtils.deleteDirectory(testDir);
     }
 
     /**
      * Tests that a file is correctly made absolute by prepending the base directory to it.
      */
     @Test
-    public void testAbsolutizeFile() {
+    public void testAbsolutizeFile() throws IOException {
         final File testDir = tmpFolder.newFolder("absolute");
         final File testFile = new File("testFile");
         final String expectedPath = testDir.getPath() + File.separator + testFile.getPath();
         File returnedFile = FilePathUtil.absolutize(testDir, testFile);
 
         assertTrue("Expected: " + expectedPath + " but was: " + returnedFile.getPath(), expectedPath.equalsIgnoreCase(returnedFile.getPath()));
+        // clean up just in case other tests create the same dirs/files
+        FileUtils.deleteDirectory(testDir);
     }
 
     /**
@@ -676,9 +687,11 @@ public class FilePathUtilTest {
     }
 
     @Test
-    public void testIllegalCharacterDetectedInPath(){
+    public void testIllegalCharacterDetectedInPath() throws IOException {
         final File testFile = tmpFolder.newFolder("badFileName:oops");
         Assert.assertFalse(FilePathUtil.hasValidFilePath(testFile));
+        // clean up just in case other tests create the same dirs/files
+        FileUtils.deleteDirectory(testFile);
     }
 
     /**

--- a/maven/project/pom.xml
+++ b/maven/project/pom.xml
@@ -110,7 +110,7 @@
     <!-- Version of SLF4J in use -->
     <dcs.project.slf4j.version>1.7.10</dcs.project.slf4j.version>
     <!-- Version of JUnit in use -->
-    <dcs.project.junit.version>4.9</dcs.project.junit.version>
+    <dcs.project.junit.version>4.12</dcs.project.junit.version>
     <!-- Version of Apache HTTP Components in use -->
     <dcs.project.httpcomponents.version>4.3.3</dcs.project.httpcomponents.version>
     <!-- Version of Apache Tika in use -->


### PR DESCRIPTION
Updated all tests that use TemporaryFolder to account for the newly added IOException by using a UUID as the dir/file name so other tests won't fail.
